### PR TITLE
Add support to update external secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.10
+FROM alpine:3.17
 
-RUN apk --update add curl bash
+RUN apk --update add curl bash jq
 
 # Download kubectl binary
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ This action will run `kubectl` to update the given deployment container with a n
 
 ## Inputs
 
-| Input     | Required | Description                                                             |
-|-----------|----------|-------------------------------------------------------------------------|
-| cert      | yes      | base64 encoded certificate                                              |
-| server    | yes      | server host                                                             |
-| token     | yes      | authentication token                                                    |
-| namespace | yes      | deployment's namespace to be updated                                    |
-| name      | yes      | deployment's name to be updated                                         |
-| image     | yes      | image name what will be used in the update, example: `org/repo:version` |
-| container | yes      | deployment's container which will be updated with new image             |
+| Input           | Required | Description                                                                                                              |
+|-----------------|----------|--------------------------------------------------------------------------------------------------------------------------|
+| cert            | yes      | base64 encoded certificate                                                                                               |
+| server          | yes      | server host                                                                                                              |
+| token           | yes      | authentication token                                                                                                     |
+| namespace       | yes      | deployment's namespace to be updated                                                                                     |
+| name            | yes      | deployment's name to be updated                                                                                          |
+| image           | yes      | image name what will be used in the update, example: `org/repo:version`                                                  |
+| container       | yes      | deployment's container which will be updated with new image                                                              |
+| external_secret | no       | If defined, it will be forced to fetch latest values from secrets provider before the image is updated in the deployment |
 
 ## Usage
 
@@ -27,6 +28,7 @@ This action will run `kubectl` to update the given deployment container with a n
       name: my_project
       image: new_image_name
       container: backend
+      external_secret: app-external-secret
 ```
 
 Enjoy 🎉

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   container:
     description: "Image to be used on update"
     required: true
+  external_secret:
+    description: "External secret name"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -l
+# exit on any error
+set -e
 
 KUBERNETES_CERT="${INPUT_CERT}"
 KUBERNETES_SERVER="${INPUT_SERVER}"
@@ -10,8 +12,9 @@ NAMESPACE="${INPUT_NAMESPACE}"
 DEPLOYMENT="${INPUT_NAME}"
 IMAGE="${INPUT_IMAGE}"
 CONTAINER="${INPUT_CONTAINER}"
+EXTERNAL_SECRET="${INPUT_EXTERNAL_SECRET}"
 
-echo "${KUBERNETES_CERT}" | base64 -d > ca.crt
+echo "${KUBERNETES_CERT}" | base64 -d >ca.crt
 
 kubectl config set-cluster "${CLUSTER_NAME}" --server="${KUBERNETES_SERVER}" --certificate-authority=ca.crt
 
@@ -21,12 +24,32 @@ kubectl config use-context "${CONTEXT}"
 
 kubectl config set-credentials "$CONTEXT" --token="$KUBERNETES_TOKEN"
 
+if [ "$EXTERNAL_SECRET" ]; then
+  if [ ! "$EXTERNAL_SECRET" ]; then
+    echo "External secret name was not defined."
+    exit 1
+  fi
+
+  echo "Checking if $EXTERNAL_SECRET exists..."
+
+  if [ "$(kubectl -n "$NAMESPACE" get es "$EXTERNAL_SECRET" -o json | jq '.status.conditions | first | .reason' | xargs)" == "SecretSynced" ]; then
+    echo "$EXTERNAL_SECRET OK"
+  else
+    echo "$EXTERNAL_SECRET has an unvalid status, please review it"
+    exit 1
+  fi
+
+  echo "Syncing secret before deployment image update..."
+
+  kubectl -n "$NAMESPACE" annotate es "$EXTERNAL_SECRET" force-sync="$(date +%s)" --overwrite
+fi
+
 echo "Deploying to ${KUBERNETES_SERVER}"
 
 echo "Updating ${DEPLOYMENT} in ${NAMESPACE} with ${IMAGE}..."
 
-IFS=',' read -ra containers <<< "$CONTAINER"
+IFS=',' read -ra containers <<<"$CONTAINER"
 
 for container in "${containers[@]}"; do
-    kubectl -n "${NAMESPACE}" set image "deployment/${DEPLOYMENT}" "${container}=${IMAGE}"
+  kubectl -n "${NAMESPACE}" set image "deployment/${DEPLOYMENT}" "${container}=${IMAGE}"
 done


### PR DESCRIPTION
Add a new input to define the name of the external secrets associated
to a deployment so it can be synced before deployment